### PR TITLE
fix(README): update readme because of go get deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Simple command line timer written in golang.
 install with
 
 ```
-go get github.com/NautiluX/timer
+go install github.com/NautiluX/timer@latest
 ```
 
 run


### PR DESCRIPTION
`go get` is deprecated for installing binaries. using `go install` is recommended and `@latest` generates pseudoversions for untagged projects like this.

fixes #1 